### PR TITLE
Fix language for poole

### DIFF
--- a/list.yaml
+++ b/list.yaml
@@ -872,6 +872,7 @@
 - name: 'poole'
   website: 'https://bitbucket.org/obensonne/poole'
   github: 'obensonne/poole'
+  language: 'Python'
   license: 'Public'
 
 


### PR DESCRIPTION
Poole is written in Python. The automatic detection incorrectly detects JavaScript (due to the shipped themes containing 3rd-party JS code).
