### PR TITLE
Add blosxom `description` and `created_at`

### DIFF
--- a/list.yaml
+++ b/list.yaml
@@ -131,6 +131,8 @@
   website: 'http://blosxom.sourceforge.net/'
   license: 'MIT'
   language: 'Perl'
+  description: 'Blosxom (pronounced "blossom") is a lightweight yet feature-packed weblog application designed from the ground up with simplicity, usability, and interoperability in mind.'
+  created_at: '2002-02-28T00:00:00Z'
 
 
 - name: 'Bonsai'


### PR DESCRIPTION
`description` taken from its official website, `created_at` taken from [Internet Archive](http://web.archive.org/web/20020613035045/http://www.oreillynet.com/~rael/2002/Feb/28).
