### PR TITLE
Add Dropplets and Leeflets

### DIFF
--- a/list.yaml
+++ b/list.yaml
@@ -270,7 +270,7 @@
 - name: 'Dropplets'
   website: 'http://dropplets.com/'
   github: 'Circa75/dropplets'
-  license: false
+  license: 'MIT'
   language: 'PHP'
 
 
@@ -634,9 +634,8 @@
 
 
 - name: 'Leeflets'
-  website: 'https://leeflets.com'
   github: 'Leeflets/leeflets'
-  license: false
+  license: 'MIT'
   language: 'PHP'
 
 


### PR DESCRIPTION
Dropplets and Leeflets, two PHP-based simple, flat file CMSes seemed to be missing from this list.
