### PR TITLE
Updated JBake github reference

### DIFF
--- a/list.yaml
+++ b/list.yaml
@@ -561,7 +561,7 @@
 
 - name: 'JBake'
   website: 'http://jbake.org/'
-  github: 'jonbullock/JBake'
+  github: 'jbake-org/jbake'
   license: 'MIT'
 
 


### PR DESCRIPTION
Updated JBake entry as project has now moved to it's own GitHub organisation.
