### PR TITLE
Link to new Cactus website

### DIFF
--- a/list.yaml
+++ b/list.yaml
@@ -185,6 +185,7 @@
 
 
 - name: 'Cactus'
+  website: 'http://cactusformac.com/'
   github: 'koenbok/Cactus'
   license: 'BSD'
 


### PR DESCRIPTION
We just shipped Cactus for Mac with a brand new website.
