### PR TITLE
Add 'Spine' as a static site generator

### DIFF
--- a/list.yaml
+++ b/list.yaml
@@ -1280,6 +1280,11 @@
   github: 'python-mg/speechhub'
   license: 'GPL'
 
+- name: 'Spine'
+  github: 'varl/spine'
+  language: 'java'
+  license: false
+  description: 'Write content in markdown and some HTML to go with it and generate it into a static site that runs from a jar'
 
 - name: 'Sphinx'
   website: 'http://sphinx-doc.org/'


### PR DESCRIPTION
Spine is a static site generator/flatfile cms written in Java and it is missing. :)
