### PR TITLE
Update list.yaml

### DIFF
--- a/list.yaml
+++ b/list.yaml
@@ -179,6 +179,7 @@
   website: 'http://bricolagecms.org/'
   description: 'Bricolage is an open-source, enterprise-class content management, workflow, and publishing system that greatly simplifies the tasks of creating, managing, and publishing vast libraries of content.'
   github: 'bricoleurs/bricolage'
+  language: 'Perl'
   license: 'BSD'
   
 - name: 'brochure'


### PR DESCRIPTION
Added Bricolage a enterprise class open source CMS which generates static html sites once they are committed. Its an old one like movable types I used it long ago.
