### PR TITLE
Adds the details for shonku.

### DIFF
--- a/list.yaml
+++ b/list.yaml
@@ -1392,6 +1392,11 @@
   github: "rtorr/serious-chicken"
   license: "MIT"
 
+- name: "Shonku"
+  website: "http://shonku.rtfd.org"
+  github: "kushaldas/shonku"
+  license: "GPL"
+  language: "Go"
 
 - name: "SG"
   github: "maxailloud/SG"


### PR DESCRIPTION
This patch adds another static blog generator written in golang, called Shonku.
