### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A comprehensive listing of static site generators with some minimal meta data ab
 There are generally three types of Content Management Systems:
 
 1. Dynamic Servers (e.g. WordPress, Ghost, DocPad, Harp) — these allow you to have re-render on every request abilities
-2. Flat File CMS (e.g. Jekyll, DocPad) — these allow you to write your content as files
+2. Flat File CMS (e.g. Yellow, Techy) — these allow you to write your content as files
 3. Static Site Generators (e.g. Jekyll, DocPad) — these generate a static website from your input that you can deploy anywhere
 
 Currently, this listing is only for projects that are either a Flat File CMS and/or Static Site Generator, but not for projects which are only Dynamic Servers (such as WordPress and Ghost).
@@ -29,8 +29,8 @@ Accepted project fields:
 
 Other fields are automatically collected from the GitHub repository but if the project does not have one you can use the following fields:
 
-* `website` - he project's website if they have one
-* `language` -the project's language (note, if the entry is closed-source, use "Web" or "App")
+* `website` - the project's website if they have one
+* `language` - the project's language (note, if the entry is closed-source, use "Web" or "App")
 * `description` - the project's description
 * `created_at` - the project's creation date in "2010-10-20T13:46:08Z" format (not needed if the project has a GitHub repo)
 


### PR DESCRIPTION
Fixed spelling and spacing, and also listed different examples for Flat File CMS as it's not very helpful to list Jekyll and DocPad as both Flat File CMS and SSGs if you're trying to differentiate.
