### PR TITLE
Remove glynn

### DIFF
--- a/list.yaml
+++ b/list.yaml
@@ -633,12 +633,6 @@
   language: "JavaScript"
   description: "Render static blog sites from Markdown using Ghost themes."
 
-- name: "glynn"
-  github: "dmathieu/glynn"
-  license: "MIT"
-  website: false
-
-
 - name: "Glyph"
   github: "h3rald/glyph"
   license: "MIT"


### PR DESCRIPTION
Glynn is not a static site generator, but just a tool to generate
a Jekyll site and upload it on a server with ftp instructions