### PR TITLE
Hugo license updated to Apache 2.0

### DIFF
--- a/list.yaml
+++ b/list.yaml
@@ -884,7 +884,7 @@
 
 - name: "Hugo"
   github: "spf13/hugo"
-  license: "SimPL"
+  license: "Apache"
   website: "http://gohugo.io/"
   language: "Go"
 


### PR DESCRIPTION
Hugo license changed to Apache 2.0 on Nov 23, 2015.
See: https://github.com/spf13/hugo/blob/master/LICENSE.md