### PR TITLE
Add REXX language.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -104,6 +104,7 @@ def check_language(language)
     "Perl",
     "Python",
     "Racket",
+    "REXX",
     "Ruby",
     "Rust",
     "Scala",


### PR DESCRIPTION
I realised that the Travis CI build is currently failing because the Rexx (Restructured Extended Executor) language wasn't recognised.

This pull request adds the language to the Rakefile so the tests pass again.

Greetings!