### PR TITLE
Add website link for Lektor

### DIFF
--- a/list.json
+++ b/list.json
@@ -1084,6 +1084,7 @@
   {
     "name": "Lektor",
     "github": "lektor/lektor",
+    "website": "https://www.getlektor.com/",
     "license": "BSD-3-Clause"
   },
   {


### PR DESCRIPTION
Add a website link for Lektor (python SSG), obtained from the project's Github repo description.