### PR TITLE
Reference the new project repository for Daux

### DIFF
--- a/source/list.ts
+++ b/source/list.ts
@@ -355,7 +355,7 @@ const rawList: RawEntry[] = [
 	},
 	{
 		name: 'Daux.io',
-		github: 'justinwalsh/daux.io',
+		github: 'dauxio/daux.io',
 		website: 'https://daux.io',
 		license: 'MIT',
 	},


### PR DESCRIPTION
Hello,

The Daux.io project was moved to an org a few years ago, the old repository still exists but is now an empty shell.