### PR TITLE
fix: vercel/next.js

### DIFF
--- a/source/list.ts
+++ b/source/list.ts
@@ -1402,8 +1402,9 @@ const rawList: RawEntry[] = [
 	},
 	{
 		name: 'Next.js',
-		github: 'zeit/next.js',
+		github: 'vercel/next.js',
 		website: 'https://nextjs.org',
+		license: 'MIT',
 	},
 	{
 		name: 'nib',


### PR DESCRIPTION
- Rename `zeit/next.js` to `vercel/next.js`
- Set license to `MIT`